### PR TITLE
feat: Stalwart app password management

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -11,7 +11,7 @@
   <description><![CDATA[An app that lets you set settings that dovecot can use
 
 See the [README](https://github.com/SUNET/nextcloud-imap_manager/blob/main/README.md) for more information.]]></description>
-  <version>0.0.4</version>
+  <version>0.0.5</version>
   <licence>agpl</licence>
   <author mail="kano@sunet.se" homepage="https://github.com/SUNET/nextcloud-imap_manager">SUNET</author>
   <namespace>ImapManager</namespace>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,6 +21,8 @@ See the [README](https://github.com/SUNET/nextcloud-imap_manager/blob/main/READM
     <nextcloud min-version="29" max-version="33" />
   </dependencies>
   <settings>
+    <admin>OCA\ImapManager\Settings\AdminSettings</admin>
+    <admin-section>OCA\ImapManager\Settings\AdminSection</admin-section>
     <personal>OCA\ImapManager\Settings\PersonalSettings</personal>
     <personal-section>OCA\ImapManager\Settings\PersonalSection</personal-section>
   </settings>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -22,5 +22,8 @@ return [
     ['name' => 'api#get_config', 'url' => '/admin/config', 'verb' => 'GET'],
     ['name' => 'api#set_config', 'url' => '/admin/config', 'verb' => 'POST'],
     ['name' => 'api#test_connection', 'url' => '/admin/test', 'verb' => 'POST'],
+    ['name' => 'api#get_stalwart', 'url' => '/stalwart/get', 'verb' => 'GET'],
+    ['name' => 'api#set_stalwart', 'url' => '/stalwart/set', 'verb' => 'POST'],
+    ['name' => 'api#delete_stalwart', 'url' => '/stalwart/delete', 'verb' => 'POST'],
   ]
 ];

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -19,5 +19,8 @@ return [
     ['name' => 'api#get', 'url' => '/get', 'verb' => 'GET'],
     ['name' => 'api#set', 'url' => '/set', 'verb' => 'POST'],
     ['name' => 'api#set_sync', 'url' => '/set_sync', 'verb' => 'POST'],
+    ['name' => 'api#get_config', 'url' => '/admin/config', 'verb' => 'GET'],
+    ['name' => 'api#set_config', 'url' => '/admin/config', 'verb' => 'POST'],
+    ['name' => 'api#test_connection', 'url' => '/admin/test', 'verb' => 'POST'],
   ]
 ];

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -13,6 +13,7 @@ use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
 use OCP\IRequest;
+use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
 
 class ApiController extends Controller
@@ -25,9 +26,16 @@ class ApiController extends Controller
     private LoggerInterface $logger,
     private IAppConfig $appConfig,
     private StalwartService $stalwartService,
+    private IUserManager $userManager,
     IRequest $request,
   ) {
     parent::__construct($appName, $request);
+  }
+
+  private function getUserEmail(): string
+  {
+    $user = $this->userManager->get($this->userId);
+    return $user->getEMailAddress() ?? $this->userId;
   }
 
   /**
@@ -39,9 +47,15 @@ class ApiController extends Controller
   {
     $ids = $this->imapManagerMapper->getIdsAndNames($this->userId);
     $values = $this->syncManagerMapper->getValues($this->userId);
-    $response = true;
-    $status = Http::STATUS_OK;
-    return new JSONResponse(array('success' => $response, 'ids' => $ids, 'values' => $values), $status);
+    $dovecotEnabled = $this->appConfig->getValueBool('imap_manager', 'dovecot_enabled', true);
+    $stalwartEnabled = $this->appConfig->getValueBool('imap_manager', 'stalwart_enabled', false);
+    return new JSONResponse([
+      'success' => true,
+      'ids' => $ids,
+      'values' => $values,
+      'dovecot_enabled' => $dovecotEnabled,
+      'stalwart_enabled' => $stalwartEnabled,
+    ], Http::STATUS_OK);
   }
 
   /**
@@ -153,5 +167,43 @@ class ApiController extends Controller
       ['status' => $success ? 'success' : 'error'],
       $success ? Http::STATUS_OK : Http::STATUS_BAD_GATEWAY
     );
+  }
+
+  #[NoAdminRequired]
+  public function getStalwart(): JSONResponse
+  {
+    $email = $this->getUserEmail();
+    $passwords = $this->stalwartService->listPasswords($email);
+    return new JSONResponse(['success' => true, 'passwords' => $passwords], Http::STATUS_OK);
+  }
+
+  #[NoAdminRequired]
+  public function setStalwart(): JSONResponse
+  {
+    $params = $this->request->getParams();
+    $name = strval($params['name']);
+    $password = strval($params['password']);
+    $email = $this->getUserEmail();
+    try {
+      $this->stalwartService->createPassword($email, $name, $password);
+      return new JSONResponse(['success' => true], Http::STATUS_OK);
+    } catch (\Exception $e) {
+      return new JSONResponse(['success' => false], Http::STATUS_BAD_GATEWAY);
+    }
+  }
+
+  #[NoAdminRequired]
+  public function deleteStalwart(): JSONResponse
+  {
+    $params = $this->request->getParams();
+    $name = strval($params['name']);
+    $password = strval($params['password']);
+    $email = $this->getUserEmail();
+    try {
+      $this->stalwartService->deletePassword($email, $name, $password);
+      return new JSONResponse(['success' => true], Http::STATUS_OK);
+    } catch (\Exception $e) {
+      return new JSONResponse(['success' => false], Http::STATUS_BAD_GATEWAY);
+    }
   }
 }

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -35,6 +35,9 @@ class ApiController extends Controller
   private function getUserEmail(): string
   {
     $user = $this->userManager->get($this->userId);
+    if ($user === null) {
+      return $this->userId;
+    }
     return $user->getEMailAddress() ?? $this->userId;
   }
 
@@ -172,17 +175,33 @@ class ApiController extends Controller
   #[NoAdminRequired]
   public function getStalwart(): JSONResponse
   {
+    if (!$this->appConfig->getValueBool('imap_manager', 'stalwart_enabled', false)) {
+      return new JSONResponse(['success' => false], Http::STATUS_FORBIDDEN);
+    }
     $email = $this->getUserEmail();
-    $passwords = $this->stalwartService->listPasswords($email);
-    return new JSONResponse(['success' => true, 'passwords' => $passwords], Http::STATUS_OK);
+    try {
+      $passwords = $this->stalwartService->listPasswords($email);
+      return new JSONResponse(['success' => true, 'passwords' => $passwords], Http::STATUS_OK);
+    } catch (\Exception $e) {
+      return new JSONResponse(['success' => false], Http::STATUS_BAD_GATEWAY);
+    }
   }
 
   #[NoAdminRequired]
   public function setStalwart(): JSONResponse
   {
+    if (!$this->appConfig->getValueBool('imap_manager', 'stalwart_enabled', false)) {
+      return new JSONResponse(['success' => false], Http::STATUS_FORBIDDEN);
+    }
     $params = $this->request->getParams();
-    $name = strval($params['name']);
-    $password = strval($params['password']);
+    $name = strval($params['name'] ?? '');
+    $password = strval($params['password'] ?? '');
+    if (empty($name) || empty($password)) {
+      return new JSONResponse(['success' => false], Http::STATUS_BAD_REQUEST);
+    }
+    if (str_contains($name, '$')) {
+      return new JSONResponse(['success' => false], Http::STATUS_BAD_REQUEST);
+    }
     $email = $this->getUserEmail();
     try {
       $this->stalwartService->createPassword($email, $name, $password);
@@ -195,9 +214,12 @@ class ApiController extends Controller
   #[NoAdminRequired]
   public function deleteStalwart(): JSONResponse
   {
+    if (!$this->appConfig->getValueBool('imap_manager', 'stalwart_enabled', false)) {
+      return new JSONResponse(['success' => false], Http::STATUS_FORBIDDEN);
+    }
     $params = $this->request->getParams();
-    $name = strval($params['name']);
-    $password = strval($params['password']);
+    $name = strval($params['name'] ?? '');
+    $password = strval($params['password'] ?? '');
     $email = $this->getUserEmail();
     try {
       $this->stalwartService->deletePassword($email, $name, $password);

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -10,6 +10,7 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IAppConfig;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
 
@@ -21,6 +22,7 @@ class ApiController extends Controller
     private ImapManagerMapper $imapManagerMapper,
     private SyncManagerMapper $syncManagerMapper,
     private LoggerInterface $logger,
+    private IAppConfig $appConfig,
     IRequest $request,
   ) {
     parent::__construct($appName, $request);
@@ -103,5 +105,47 @@ class ApiController extends Controller
       return new JSONResponse(array('success' => true), Http::STATUS_OK);
     }
     return new JSONResponse(array('success' => false), Http::STATUS_BAD_GATEWAY);
+  }
+
+  /**
+   *
+   * @return JSONResponse
+   **/
+  public function getConfig(): JSONResponse
+  {
+    $config = [
+      'stalwart_url' => $this->appConfig->getValueString('imap_manager', 'stalwart_url', ''),
+      'stalwart_admin_user' => $this->appConfig->getValueString('imap_manager', 'stalwart_admin_user', ''),
+      'stalwart_admin_password' => $this->appConfig->getValueString('imap_manager', 'stalwart_admin_password') !== '' ? '********' : '',
+      'dovecot_enabled' => $this->appConfig->getValueBool('imap_manager', 'dovecot_enabled', true),
+      'stalwart_enabled' => $this->appConfig->getValueBool('imap_manager', 'stalwart_enabled', false),
+    ];
+    return new JSONResponse($config, Http::STATUS_OK);
+  }
+
+  /**
+   *
+   * @return JSONResponse
+   **/
+  public function setConfig(): JSONResponse
+  {
+    $params = $this->request->getParams();
+    $this->appConfig->setValueString('imap_manager', 'stalwart_url', strval($params['stalwart_url'] ?? ''));
+    $this->appConfig->setValueString('imap_manager', 'stalwart_admin_user', strval($params['stalwart_admin_user'] ?? ''));
+    if (isset($params['stalwart_admin_password']) && $params['stalwart_admin_password'] !== '********') {
+      $this->appConfig->setValueString('imap_manager', 'stalwart_admin_password', strval($params['stalwart_admin_password']), sensitive: true);
+    }
+    $this->appConfig->setValueBool('imap_manager', 'dovecot_enabled', boolval($params['dovecot_enabled'] ?? true));
+    $this->appConfig->setValueBool('imap_manager', 'stalwart_enabled', boolval($params['stalwart_enabled'] ?? false));
+    return new JSONResponse(['status' => 'success'], Http::STATUS_OK);
+  }
+
+  /**
+   *
+   * @return JSONResponse
+   **/
+  public function testConnection(): JSONResponse
+  {
+    return new JSONResponse(['status' => 'not_implemented'], Http::STATUS_OK);
   }
 }

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -6,6 +6,7 @@ use OCA\ImapManager\Db\ImapManager;
 use OCA\ImapManager\Db\ImapManagerMapper;
 use OCA\ImapManager\Db\SyncManager;
 use OCA\ImapManager\Db\SyncManagerMapper;
+use OCA\ImapManager\Service\StalwartService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
@@ -23,6 +24,7 @@ class ApiController extends Controller
     private SyncManagerMapper $syncManagerMapper,
     private LoggerInterface $logger,
     private IAppConfig $appConfig,
+    private StalwartService $stalwartService,
     IRequest $request,
   ) {
     parent::__construct($appName, $request);
@@ -146,6 +148,10 @@ class ApiController extends Controller
    **/
   public function testConnection(): JSONResponse
   {
-    return new JSONResponse(['status' => 'not_implemented'], Http::STATUS_OK);
+    $success = $this->stalwartService->testConnection();
+    return new JSONResponse(
+      ['status' => $success ? 'success' : 'error'],
+      $success ? Http::STATUS_OK : Http::STATUS_BAD_GATEWAY
+    );
   }
 }

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -9,6 +9,7 @@ use OCA\ImapManager\Db\SyncManagerMapper;
 use OCA\ImapManager\Service\StalwartService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AdminRequired;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
@@ -130,6 +131,7 @@ class ApiController extends Controller
    *
    * @return JSONResponse
    **/
+  #[AdminRequired]
   public function getConfig(): JSONResponse
   {
     $config = [
@@ -146,6 +148,7 @@ class ApiController extends Controller
    *
    * @return JSONResponse
    **/
+  #[AdminRequired]
   public function setConfig(): JSONResponse
   {
     $params = $this->request->getParams();
@@ -163,6 +166,7 @@ class ApiController extends Controller
    *
    * @return JSONResponse
    **/
+  #[AdminRequired]
   public function testConnection(): JSONResponse
   {
     $success = $this->stalwartService->testConnection();
@@ -220,6 +224,12 @@ class ApiController extends Controller
     $params = $this->request->getParams();
     $name = strval($params['name'] ?? '');
     $password = strval($params['password'] ?? '');
+    if (empty($name) || empty($password)) {
+      return new JSONResponse(['success' => false], Http::STATUS_BAD_REQUEST);
+    }
+    if (str_contains($name, '$')) {
+      return new JSONResponse(['success' => false], Http::STATUS_BAD_REQUEST);
+    }
     $email = $this->getUserEmail();
     try {
       $this->stalwartService->deletePassword($email, $name, $password);

--- a/lib/Service/StalwartService.php
+++ b/lib/Service/StalwartService.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+// SPDX-FileCopyrightText: 2025 Mikael Nordin <kano@sunet.se>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\ImapManager\Service;
+
+use OCP\Http\Client\IClientService;
+use OCP\IAppConfig;
+use Psr\Log\LoggerInterface;
+
+class StalwartService
+{
+    public function __construct(
+        private IAppConfig $appConfig,
+        private IClientService $clientService,
+        private LoggerInterface $logger,
+    ) {}
+
+    private function getBaseUrl(): string
+    {
+        return rtrim($this->appConfig->getValueString('imap_manager', 'stalwart_url', ''), '/');
+    }
+
+    private function getAuthHeader(): string
+    {
+        $user = $this->appConfig->getValueString('imap_manager', 'stalwart_admin_user', '');
+        $password = $this->appConfig->getValueString('imap_manager', 'stalwart_admin_password', '');
+        return 'Basic ' . base64_encode($user . ':' . $password);
+    }
+
+    private function request(string $method, string $path, ?array $body = null): array
+    {
+        $client = $this->clientService->newClient();
+        $url = $this->getBaseUrl() . $path;
+        $options = [
+            'headers' => [
+                'Authorization' => $this->getAuthHeader(),
+                'Content-Type' => 'application/json',
+            ],
+        ];
+        if ($body !== null) {
+            $options['body'] = json_encode($body);
+        }
+        $response = $client->$method($url, $options);
+        $responseBody = $response->getBody();
+        return json_decode($responseBody, true) ?? [];
+    }
+
+    public function listPasswords(string $email): array
+    {
+        $data = $this->request('get', '/api/principal/' . urlencode($email));
+        $secrets = $data['data']['secrets'] ?? [];
+        $passwords = [];
+        foreach ($secrets as $secret) {
+            if (str_starts_with($secret, '$app$')) {
+                $parts = explode('$', $secret);
+                // Format: $app$name$password — split gives ['', 'app', 'name', 'password']
+                if (count($parts) >= 4) {
+                    $passwords[] = [
+                        'name' => $parts[2],
+                        'password' => $parts[3],
+                    ];
+                }
+            }
+        }
+        return $passwords;
+    }
+
+    public function createPassword(string $email, string $name, string $password): void
+    {
+        $value = '$app$' . $name . '$' . $password;
+        $this->request('patch', '/api/principal/' . urlencode($email), [
+            ['action' => 'addItem', 'field' => 'secrets', 'value' => $value],
+        ]);
+    }
+
+    public function deletePassword(string $email, string $name, string $password): void
+    {
+        $value = '$app$' . $name . '$' . $password;
+        $this->request('patch', '/api/principal/' . urlencode($email), [
+            ['action' => 'removeItem', 'field' => 'secrets', 'value' => $value],
+        ]);
+    }
+
+    public function testConnection(): bool
+    {
+        try {
+            $this->request('get', '/api/principal/admin');
+            return true;
+        } catch (\Exception $e) {
+            $this->logger->warning('Stalwart connection test failed: ' . $e->getMessage());
+            return false;
+        }
+    }
+}

--- a/lib/Service/StalwartService.php
+++ b/lib/Service/StalwartService.php
@@ -87,7 +87,8 @@ class StalwartService
     public function testConnection(): bool
     {
         try {
-            $this->request('get', '/api/principal/admin');
+            $adminUser = $this->appConfig->getValueString('imap_manager', 'stalwart_admin_user', 'admin');
+            $this->request('get', '/api/principal/' . urlencode($adminUser));
             return true;
         } catch (\Exception $e) {
             $this->logger->warning('Stalwart connection test failed: ' . $e->getMessage());

--- a/lib/Settings/AdminSection.php
+++ b/lib/Settings/AdminSection.php
@@ -1,5 +1,9 @@
 <?php
 
+declare(strict_types=1);
+// SPDX-FileCopyrightText: 2025 Mikael Nordin <kano@sunet.se>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 namespace OCA\ImapManager\Settings;
 
 use OCP\IL10N;

--- a/lib/Settings/AdminSection.php
+++ b/lib/Settings/AdminSection.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace OCA\ImapManager\Settings;
+
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\Settings\IIconSection;
+
+class AdminSection implements IIconSection
+{
+    public function __construct(
+        private IURLGenerator $urlGenerator,
+        private IL10N $l
+    ) {}
+
+    public function getID(): string
+    {
+        return 'connected-accounts';
+    }
+
+    public function getName(): string
+    {
+        return $this->l->t('Connected accounts');
+    }
+
+    public function getPriority(): int
+    {
+        return 90;
+    }
+
+    public function getIcon(): string
+    {
+        return $this->urlGenerator->imagePath('core', 'categories/integration.svg');
+    }
+}

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -1,5 +1,9 @@
 <?php
 
+declare(strict_types=1);
+// SPDX-FileCopyrightText: 2025 Mikael Nordin <kano@sunet.se>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 namespace OCA\ImapManager\Settings;
 
 use OCA\ImapManager\AppInfo\Application;

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace OCA\ImapManager\Settings;
+
+use OCA\ImapManager\AppInfo\Application;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\Settings\ISettings;
+
+class AdminSettings implements ISettings
+{
+    public function __construct() {}
+
+    public function getForm(): TemplateResponse
+    {
+        return new TemplateResponse(Application::APP_ID, 'adminSettings');
+    }
+
+    public function getSection(): string
+    {
+        return 'connected-accounts';
+    }
+
+    public function getPriority(): int
+    {
+        return 10;
+    }
+}

--- a/src/adminSettings.js
+++ b/src/adminSettings.js
@@ -1,0 +1,13 @@
+import { createApp } from 'vue'
+import AdminSettings from './components/AdminSettings.vue'
+
+const app = createApp(AdminSettings)
+
+app.mixin({
+  methods: {
+    t,
+    n
+  }
+})
+
+app.mount('#imap_manager_admin')

--- a/src/adminSettings.js
+++ b/src/adminSettings.js
@@ -1,3 +1,11 @@
+/**
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Micke Nordin <kano@sunet.se>
+ * @copyright Micke Nordin 2025
+ */
+
 import { createApp } from 'vue'
 import AdminSettings from './components/AdminSettings.vue'
 

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -1,0 +1,177 @@
+<template>
+  <NcSettingsSection
+    id="imap-manager-admin"
+    name="IMAP Manager"
+    description="Configure mail server backends for app password management."
+  >
+    <div class="wrapper">
+      <p><strong>Backend Toggles</strong></p>
+      <NcCheckboxRadioSwitch
+        :checked="dovecotEnabled"
+        @update:checked="dovecotEnabled = $event"
+      >
+        Enable Dovecot backend
+      </NcCheckboxRadioSwitch>
+      <NcCheckboxRadioSwitch
+        :checked="stalwartEnabled"
+        @update:checked="stalwartEnabled = $event"
+      >
+        Enable Stalwart backend
+      </NcCheckboxRadioSwitch>
+    </div>
+    <div class="wrapper" v-if="stalwartEnabled">
+      <p><strong>Stalwart Configuration</strong></p>
+      <div class="external-label">
+        <label for="StalwartUrl">Stalwart API URL</label>
+        <NcTextField
+          id="StalwartUrl"
+          v-model="stalwartUrl"
+          :label-outside="true"
+          placeholder="https://mail.example.com/api"
+        />
+      </div>
+      <div class="external-label">
+        <label for="StalwartAdminUser">Admin Username</label>
+        <NcTextField
+          id="StalwartAdminUser"
+          v-model="stalwartAdminUser"
+          :label-outside="true"
+          placeholder="admin"
+        />
+      </div>
+      <div class="external-label">
+        <label for="StalwartAdminPassword">Admin Password</label>
+        <NcPasswordField
+          id="StalwartAdminPassword"
+          v-model="stalwartAdminPassword"
+          :label-outside="true"
+          placeholder="Admin Password"
+        />
+      </div>
+      <div class="button-row">
+        <NcButton @click="testConnection" variant="secondary">
+          <template #icon>
+            <Connection :size="20" />
+          </template>
+          Test Connection
+        </NcButton>
+      </div>
+      <p v-if="testResult === 'success'" class="msg success">Connection successful</p>
+      <p v-if="testResult === 'error'" class="msg error">Connection failed</p>
+    </div>
+    <div class="wrapper">
+      <NcButton @click="save" variant="primary">
+        <template #icon>
+          <Check :size="20" />
+        </template>
+        Save
+      </NcButton>
+      <p v-if="saved" class="msg success">Settings saved</p>
+    </div>
+  </NcSettingsSection>
+</template>
+
+<script>
+import Check from "vue-material-design-icons/Check.vue";
+import Connection from "vue-material-design-icons/Connection.vue";
+
+import {
+  NcButton,
+  NcCheckboxRadioSwitch,
+  NcPasswordField,
+  NcSettingsSection,
+  NcTextField,
+} from "@nextcloud/vue";
+
+import axios from "@nextcloud/axios";
+import { generateUrl } from "@nextcloud/router";
+
+export default {
+  name: "AdminSettings",
+
+  components: {
+    Check,
+    Connection,
+    NcButton,
+    NcCheckboxRadioSwitch,
+    NcPasswordField,
+    NcSettingsSection,
+    NcTextField,
+  },
+
+  data() {
+    return {
+      dovecotEnabled: true,
+      stalwartEnabled: false,
+      stalwartUrl: "",
+      stalwartAdminUser: "",
+      stalwartAdminPassword: "",
+      testResult: null,
+      saved: false,
+    };
+  },
+
+  mounted() {
+    this.loadConfig();
+  },
+
+  methods: {
+    async loadConfig() {
+      const url = generateUrl("/apps/imap_manager/admin/config");
+      const result = await axios.get(url);
+      this.dovecotEnabled = result.data.dovecot_enabled;
+      this.stalwartEnabled = result.data.stalwart_enabled;
+      this.stalwartUrl = result.data.stalwart_url;
+      this.stalwartAdminUser = result.data.stalwart_admin_user;
+      this.stalwartAdminPassword = result.data.stalwart_admin_password;
+    },
+
+    async save() {
+      const url = generateUrl("/apps/imap_manager/admin/config");
+      await axios.post(url, {
+        dovecot_enabled: this.dovecotEnabled,
+        stalwart_enabled: this.stalwartEnabled,
+        stalwart_url: this.stalwartUrl,
+        stalwart_admin_user: this.stalwartAdminUser,
+        stalwart_admin_password: this.stalwartAdminPassword,
+      });
+      this.saved = true;
+      setTimeout(() => { this.saved = false; }, 3000);
+    },
+
+    async testConnection() {
+      this.testResult = null;
+      const url = generateUrl("/apps/imap_manager/admin/test");
+      try {
+        const result = await axios.post(url);
+        this.testResult = result.data.status === "success" ? "success" : "error";
+      } catch (e) {
+        this.testResult = "error";
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.wrapper {
+  margin-bottom: 16px;
+}
+.external-label {
+  margin-bottom: 8px;
+}
+.button-row {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+.msg {
+  margin-top: 8px;
+  font-weight: bold;
+}
+.msg.success {
+  color: var(--color-success);
+}
+.msg.error {
+  color: var(--color-error);
+}
+</style>

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -52,7 +52,7 @@
               <NcPasswordField
                 id="token"
                 v-model="token"
-                :label="App - password"
+                label="App-password"
               />
             </div>
           </div>

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -6,86 +6,187 @@
     description="Generate app-password for IMAP."
     @default="populate"
   >
-    <div class="wrapper">
-      <NcTextField
-        id="Name"
-        label="Name"
-        v-model="name"
-        placeholder="Enter app-password name"
-        style="width: 50%"
-      />
-      <br />
-      <NcButton
-        @click="set()"
-        aria-label="Save"
-        :disabled="disabled"
-        :size="size"
-        variant="primary"
-      >
-        <template #default>Save</template>
-      </NcButton>
-    </div>
-    <br />
-    <NcDialog v-if="showDialog" name="App-password" :can-close="false">
-      <template #actions>
+    <div v-if="dovecotEnabled">
+      <p><strong>Dovecot Password Manager</strong></p>
+      <div class="wrapper">
+        <NcTextField
+          id="Name"
+          label="Name"
+          v-model="name"
+          placeholder="Enter app-password name"
+          style="width: 50%"
+        />
+        <br />
         <NcButton
-          @click="showDialog = false"
-          aria-label="Cancel"
-          variant="tertiary"
+          @click="set()"
+          aria-label="Save"
+          :disabled="disabled"
+          :size="size"
+          variant="primary"
         >
-          <template #icon>
-            <Cancel :size="16" />
-          </template>
+          <template #default>Save</template>
         </NcButton>
-        <NcButton @click="copy()" aria-label="Copy" variant="tertiary">
-          <template #icon>
-            <IconClipboard size="16" />
-          </template>
-        </NcButton>
-      </template>
-      <template #default>
-        <div class="wrapper">
-          <div>App-password will not be shown again.</div>
-          <div id="app-password">
-            <NcPasswordField
-              id="token"
-              v-model="token"
-              :label="App - password"
-            />
+      </div>
+      <br />
+      <NcDialog v-if="showDialog" name="App-password" :can-close="false">
+        <template #actions>
+          <NcButton
+            @click="showDialog = false"
+            aria-label="Cancel"
+            variant="tertiary"
+          >
+            <template #icon>
+              <Cancel :size="16" />
+            </template>
+          </NcButton>
+          <NcButton @click="copy()" aria-label="Copy" variant="tertiary">
+            <template #icon>
+              <IconClipboard size="16" />
+            </template>
+          </NcButton>
+        </template>
+        <template #default>
+          <div class="wrapper">
+            <div>App-password will not be shown again.</div>
+            <div id="app-password">
+              <NcPasswordField
+                id="token"
+                v-model="token"
+                :label="App - password"
+              />
+            </div>
           </div>
-        </div>
-      </template>
-    </NcDialog>
-    <div class="wrapper" v-if="tokens.length > 0">
-      <p><strong>Issued app-passwords</strong></p>
-      <ul style="width: 50%">
-        <NcListItem
-          v-for="token in tokens"
-          v-bind:key="token.id"
-          bold
-          compact="true"
-          name="token.name"
-          oneline
+        </template>
+      </NcDialog>
+      <div class="wrapper" v-if="tokens.length > 0">
+        <p><strong>Issued app-passwords</strong></p>
+        <ul style="width: 50%">
+          <NcListItem
+            v-for="token in tokens"
+            v-bind:key="token.id"
+            bold
+            compact="true"
+            name="token.name"
+            oneline
+          >
+            <template #icon>
+              <Key :size="16" />
+            </template>
+            <template #name>
+              {{ token.name }}
+            </template>
+            <template #details>
+              <NcButton
+                @click="unset(token.id)"
+                aria-label="Delete"
+                variant="tertiary"
+              >
+                <template #icon>
+                  <Delete :size="16" />
+                </template>
+              </NcButton>
+            </template>
+          </NcListItem>
+        </ul>
+      </div>
+    </div>
+    <div v-if="stalwartEnabled">
+      <p><strong>Stalwart Password Manager</strong></p>
+      <div class="wrapper">
+        <NcTextField
+          id="StalwartName"
+          label="Name"
+          v-model="stalwartName"
+          placeholder="Enter app-password name"
+          style="width: 50%"
+        />
+        <br />
+        <NcButton
+          @click="setStalwart()"
+          aria-label="Save"
+          variant="primary"
         >
-          <template #icon>
-            <Key :size="16" />
-          </template>
-          <template #name>
-            {{ token.name }}
-          </template>
-          <template #details>
-            <NcButton
-              @click="unset(token.id)"
-              aria-label="Delete"
-              variant="tertiary"
-            >
-              <template #icon>
-                <Delete :size="16" />
-              </template>
-            </NcButton>
-          </template>
-        </NcListItem>
-      </ul>
+          <template #default>Generate</template>
+        </NcButton>
+      </div>
+      <br />
+      <NcDialog v-if="showStalwartDialog" name="Stalwart App Password" :can-close="false">
+        <template #actions>
+          <NcButton
+            @click="showStalwartDialog = false"
+            aria-label="Cancel"
+            variant="tertiary"
+          >
+            <template #icon>
+              <Cancel :size="16" />
+            </template>
+          </NcButton>
+          <NcButton @click="copyStalwart()" aria-label="Copy" variant="tertiary">
+            <template #icon>
+              <IconClipboard size="16" />
+            </template>
+          </NcButton>
+        </template>
+        <template #default>
+          <div class="wrapper">
+            <div>Save this password now — you can reveal it later, but it's easier to copy it now.</div>
+            <div>
+              <NcPasswordField
+                id="stalwart-token"
+                v-model="stalwartToken"
+                label="App Password"
+              />
+            </div>
+          </div>
+        </template>
+      </NcDialog>
+      <div class="wrapper" v-if="stalwartPasswords.length > 0">
+        <p><strong>Issued Stalwart passwords</strong></p>
+        <ul style="width: 50%">
+          <NcListItem
+            v-for="pw in stalwartPasswords"
+            v-bind:key="pw.name + pw.password"
+            bold
+            compact="true"
+            :name="pw.name"
+            oneline
+          >
+            <template #icon>
+              <Key :size="16" />
+            </template>
+            <template #name>
+              {{ pw.name }}
+            </template>
+            <template #subname>
+              {{ pw.revealed ? pw.password : '••••••••' }}
+            </template>
+            <template #details>
+              <NcButton
+                @click="pw.revealed = !pw.revealed"
+                aria-label="Reveal"
+                variant="tertiary"
+              >
+                <template #icon>
+                  <EyeOff v-if="pw.revealed" :size="16" />
+                  <Eye v-else :size="16" />
+                </template>
+              </NcButton>
+              <NcButton
+                @click="deleteStalwart(pw.name, pw.password)"
+                aria-label="Delete"
+                variant="tertiary"
+              >
+                <template #icon>
+                  <Delete :size="16" />
+                </template>
+              </NcButton>
+            </template>
+          </NcListItem>
+        </ul>
+      </div>
+    </div>
+    <div v-if="!dovecotEnabled && !stalwartEnabled">
+      <p>No mail backends configured. Contact your administrator.</p>
     </div>
     <div class="wrapper">
       <p><strong>Sync settings</strong></p>
@@ -185,6 +286,8 @@ import Delete from "vue-material-design-icons/Delete.vue";
 import IconClipboard from "vue-material-design-icons/ContentCopy.vue";
 import IconStar from "vue-material-design-icons/Star.vue";
 import IconStarOutline from "vue-material-design-icons/StarOutline.vue";
+import Eye from "vue-material-design-icons/Eye.vue";
+import EyeOff from "vue-material-design-icons/EyeOff.vue";
 import Key from "vue-material-design-icons/Key.vue";
 
 import {
@@ -211,6 +314,8 @@ export default {
   components: {
     Cancel,
     Delete,
+    Eye,
+    EyeOff,
     IconClipboard,
     IconStar,
     IconStarOutline,
@@ -241,6 +346,12 @@ export default {
       radioValue: "m365",
       optionsValue: "daily",
       whatValue: [],
+      dovecotEnabled: true,
+      stalwartEnabled: false,
+      stalwartPasswords: [],
+      stalwartName: "",
+      stalwartToken: "",
+      showStalwartDialog: false,
     };
   },
   methods: {
@@ -285,6 +396,8 @@ export default {
       if ("ids" in result.data) {
         this.tokens = result.data.ids;
       }
+      this.dovecotEnabled = result.data.dovecot_enabled ?? true;
+      this.stalwartEnabled = result.data.stalwart_enabled ?? false;
       let values = result.data.values;
       console.log(values);
       if (values) {
@@ -307,6 +420,9 @@ export default {
         console.log("radioValue: " + this.radioValue + " " + values.source);
       }
       console.log("IMAP passwords and sync settings loaded");
+      if (this.stalwartEnabled) {
+        await this.loadStalwartPasswords();
+      }
     },
     async set() {
       if (!this.name) {
@@ -380,6 +496,56 @@ export default {
             break;
           }
         }
+      }
+    },
+    async loadStalwartPasswords() {
+      let url = "/apps/imap_manager/stalwart/get";
+      let result = await this.csrfRequest(url, "GET");
+      if (result.data.success) {
+        this.stalwartPasswords = result.data.passwords.map((p) => ({
+          ...p,
+          revealed: false,
+        }));
+      }
+    },
+    async setStalwart() {
+      if (!this.stalwartName) {
+        return;
+      }
+      this.stalwartToken = uuidv4();
+      let url = "/apps/imap_manager/stalwart/set";
+      let params = { name: this.stalwartName, password: this.stalwartToken };
+      let result = await this.csrfRequest(url, "POST", params);
+      if (result.data.success) {
+        this.showStalwartDialog = true;
+        this.stalwartPasswords.push({
+          name: this.stalwartName,
+          password: this.stalwartToken,
+          revealed: false,
+        });
+        this.stalwartName = "";
+      }
+    },
+    async deleteStalwart(name, password) {
+      let url = "/apps/imap_manager/stalwart/delete";
+      let params = { name: name, password: password };
+      let result = await this.csrfRequest(url, "POST", params);
+      if (result.data.success) {
+        this.stalwartPasswords = this.stalwartPasswords.filter(
+          (p) => !(p.name === name && p.password === password)
+        );
+      }
+    },
+    async copyStalwart() {
+      try {
+        await navigator.clipboard.writeText(this.stalwartToken);
+        showSuccess(t("imap_manager", "Password copied to the clipboard"));
+        this.showStalwartDialog = false;
+      } catch (e) {
+        window.prompt(
+          t("imap_manager", "Clipboard not available. Please copy the password manually."),
+          this.stalwartToken,
+        );
       }
     },
   },

--- a/templates/adminSettings.php
+++ b/templates/adminSettings.php
@@ -1,0 +1,6 @@
+<?php
+$appId = OCA\ImapManager\AppInfo\Application::APP_ID;
+\OCP\Util::addScript($appId, $appId . '-adminSettings');
+?>
+
+<div id="imap_manager_admin"></div>

--- a/webpack.js
+++ b/webpack.js
@@ -8,5 +8,9 @@ webpackConfig.entry = {
     import: path.join(__dirname, "src", "personalSettings.js"),
     filename: appId + "-personalSettings.js",
   },
+  adminSettings: {
+    import: path.join(__dirname, "src", "adminSettings.js"),
+    filename: appId + "-adminSettings.js",
+  },
 };
 module.exports = webpackConfig;


### PR DESCRIPTION
## Summary
- Add admin settings section/UI for configuring the Stalwart admin API backend (endpoint, admin user, enable flag, test-connection stub).
- Add `StalwartService` and API endpoints for listing, creating, and deleting per-user app passwords via the Stalwart admin API (`$app$name$password` format).
- Add a Stalwart app passwords section to the personal settings UI, gated by the `stalwart_enabled` flag.

## Test plan
- [ ] Enable Stalwart in admin settings and verify the test-connection stub responds.
- [ ] From personal settings, create an app password and confirm it appears in Stalwart.
- [ ] Delete an app password and confirm it is removed in Stalwart.
- [ ] Verify name validation rejects empty values and names containing `$`.
- [ ] Verify personal settings endpoints are gated when `stalwart_enabled` is off.