### PR TITLE
fix: address security audit (C1, H1, H4, M1-M5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
 A database table of hashes and salts that dovecot can use to authenticate, with a slick web gui in Nextcloud
 
 ![Image](screenshots/security.png)
+
+## ⚠️ Security: disable user-editable email
+
+**When the Stalwart backend is enabled, you MUST prevent users from
+changing their own email address.**
+
+This app uses the Nextcloud user's email address as the Stalwart
+principal identifier for app-password CRUD. A user who can change their
+own email to another user's (or an admin's) address can read, add, or
+delete that user's Stalwart app passwords.
+
+### What to do
+
+As admin, lock down the email field on the profile settings so regular
+users cannot change it. Admins can still change user emails via the
+user management UI or `occ user:setting <uid> settings email <value>`
+— this is a privileged operation, and admins should know that changing
+a user's email also moves that user's Stalwart mailbox identity.
+
+For LDAP-backed deployments, ensure the email attribute is not
+user-writable in the directory.

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -2,9 +2,7 @@
 
 namespace OCA\ImapManager\Controller;
 
-use OCA\ImapManager\Db\ImapManager;
 use OCA\ImapManager\Db\ImapManagerMapper;
-use OCA\ImapManager\Db\SyncManager;
 use OCA\ImapManager\Db\SyncManagerMapper;
 use OCA\ImapManager\Service\StalwartService;
 use OCP\AppFramework\Controller;
@@ -72,17 +70,12 @@ class ApiController extends Controller
     $params = $this->request->getParams();
     $name = strval($params['name']);
     $token = strval($params['token']);
-    /**
-     * @var ImapManager
-     */
-    $imapManager = $this->imapManagerMapper->set($this->userId, $token, $name);
-    $response = true;
-    $status = Http::STATUS_OK;
-    if (!$imapManager) {
-      $response = false;
-      $status = Http::STATUS_BAD_GATEWAY;
+    try {
+      $imapManager = $this->imapManagerMapper->set($this->userId, $token, $name);
+    } catch (\InvalidArgumentException $e) {
+      return new JSONResponse(['success' => false], Http::STATUS_BAD_REQUEST);
     }
-    return new JSONResponse(array('success' => $response, 'id' => $imapManager->getId()), $status);
+    return new JSONResponse(['success' => true, 'id' => $imapManager->getId()], Http::STATUS_OK);
   }
 
   /**
@@ -94,22 +87,23 @@ class ApiController extends Controller
   {
     $params = $this->request->getParams();
     $frequency = strval($params['frequency']);
+    if (!in_array($frequency, ['daily', 'hourly', 'minutely'], true)) {
+      return new JSONResponse(['success' => false], Http::STATUS_BAD_REQUEST);
+    }
+    $primary = strval($params['primary']);
+    if (!in_array($primary, ['sunet', 'm365'], true)) {
+      return new JSONResponse(['success' => false], Http::STATUS_BAD_REQUEST);
+    }
     $calendar  = boolval($params['calendar']);
     $contacts  = boolval($params['contacts']);
     $email     = boolval($params['email']);
     $enabled   = boolval($params['enabled']);
-    $primary   = strval($params['primary']);
-    /**
-     * @var SyncManager
-     */
-    $syncManager = $this->syncManagerMapper->set($this->userId, $frequency, $calendar, $contacts, $email, $primary, $enabled);
-    $response = true;
-    $status = Http::STATUS_OK;
-    if (!$syncManager) {
-      $response = false;
-      $status = Http::STATUS_BAD_GATEWAY;
+    try {
+      $syncManager = $this->syncManagerMapper->set($this->userId, $frequency, $calendar, $contacts, $email, $primary, $enabled);
+    } catch (\InvalidArgumentException $e) {
+      return new JSONResponse(['success' => false], Http::STATUS_BAD_REQUEST);
     }
-    return new JSONResponse(array('success' => $response, 'id' => $syncManager->getId()), $status);
+    return new JSONResponse(['success' => true, 'id' => $syncManager->getId()], Http::STATUS_OK);
   }
 
   /**
@@ -119,12 +113,16 @@ class ApiController extends Controller
   #[NoAdminRequired]
   public function delete(int $id): JSONResponse
   {
-    $imapManager = $this->imapManagerMapper->get($id);
-    if ($imapManager) {
-      $this->imapManagerMapper->delete($imapManager);
-      return new JSONResponse(array('success' => true), Http::STATUS_OK);
+    try {
+      $imapManager = $this->imapManagerMapper->get($id);
+    } catch (\InvalidArgumentException $e) {
+      return new JSONResponse(['success' => false], Http::STATUS_NOT_FOUND);
     }
-    return new JSONResponse(array('success' => false), Http::STATUS_BAD_GATEWAY);
+    if ($imapManager->getUserId() !== $this->userId) {
+      return new JSONResponse(['success' => false], Http::STATUS_FORBIDDEN);
+    }
+    $this->imapManagerMapper->delete($imapManager);
+    return new JSONResponse(['success' => true], Http::STATUS_OK);
   }
 
   /**
@@ -203,7 +201,7 @@ class ApiController extends Controller
     if (empty($name) || empty($password)) {
       return new JSONResponse(['success' => false], Http::STATUS_BAD_REQUEST);
     }
-    if (str_contains($name, '$')) {
+    if (str_contains($name, '$') || str_contains($password, '$')) {
       return new JSONResponse(['success' => false], Http::STATUS_BAD_REQUEST);
     }
     $email = $this->getUserEmail();
@@ -227,7 +225,7 @@ class ApiController extends Controller
     if (empty($name) || empty($password)) {
       return new JSONResponse(['success' => false], Http::STATUS_BAD_REQUEST);
     }
-    if (str_contains($name, '$')) {
+    if (str_contains($name, '$') || str_contains($password, '$')) {
       return new JSONResponse(['success' => false], Http::STATUS_BAD_REQUEST);
     }
     $email = $this->getUserEmail();

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace OCA\ImapManager\Controller;
 
 use OCA\ImapManager\Db\ImapManagerMapper;
@@ -9,6 +11,7 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\AdminRequired;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\PasswordConfirmationRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
 use OCP\IRequest;
@@ -65,6 +68,7 @@ class ApiController extends Controller
    * @return JSONResponse
    **/
   #[NoAdminRequired]
+  #[PasswordConfirmationRequired]
   public function set(): JSONResponse
   {
     $params = $this->request->getParams();
@@ -111,6 +115,7 @@ class ApiController extends Controller
    * @return JSONResponse
    **/
   #[NoAdminRequired]
+  #[PasswordConfirmationRequired]
   public function delete(int $id): JSONResponse
   {
     try {
@@ -147,10 +152,15 @@ class ApiController extends Controller
    * @return JSONResponse
    **/
   #[AdminRequired]
+  #[PasswordConfirmationRequired]
   public function setConfig(): JSONResponse
   {
     $params = $this->request->getParams();
-    $this->appConfig->setValueString('imap_manager', 'stalwart_url', strval($params['stalwart_url'] ?? ''));
+    $stalwartUrl = strval($params['stalwart_url'] ?? '');
+    if ($stalwartUrl !== '' && !$this->isValidStalwartUrl($stalwartUrl)) {
+      return new JSONResponse(['success' => false, 'error' => 'invalid_url'], Http::STATUS_BAD_REQUEST);
+    }
+    $this->appConfig->setValueString('imap_manager', 'stalwart_url', $stalwartUrl);
     $this->appConfig->setValueString('imap_manager', 'stalwart_admin_user', strval($params['stalwart_admin_user'] ?? ''));
     if (isset($params['stalwart_admin_password']) && $params['stalwart_admin_password'] !== '********') {
       $this->appConfig->setValueString('imap_manager', 'stalwart_admin_password', strval($params['stalwart_admin_password']), sensitive: true);
@@ -158,6 +168,15 @@ class ApiController extends Controller
     $this->appConfig->setValueBool('imap_manager', 'dovecot_enabled', boolval($params['dovecot_enabled'] ?? true));
     $this->appConfig->setValueBool('imap_manager', 'stalwart_enabled', boolval($params['stalwart_enabled'] ?? false));
     return new JSONResponse(['status' => 'success'], Http::STATUS_OK);
+  }
+
+  private function isValidStalwartUrl(string $url): bool
+  {
+    $parsed = parse_url($url);
+    if ($parsed === false || !isset($parsed['scheme'], $parsed['host'])) {
+      return false;
+    }
+    return in_array(strtolower($parsed['scheme']), ['http', 'https'], true);
   }
 
   /**
@@ -190,6 +209,7 @@ class ApiController extends Controller
   }
 
   #[NoAdminRequired]
+  #[PasswordConfirmationRequired]
   public function setStalwart(): JSONResponse
   {
     if (!$this->appConfig->getValueBool('imap_manager', 'stalwart_enabled', false)) {
@@ -214,6 +234,7 @@ class ApiController extends Controller
   }
 
   #[NoAdminRequired]
+  #[PasswordConfirmationRequired]
   public function deleteStalwart(): JSONResponse
   {
     if (!$this->appConfig->getValueBool('imap_manager', 'stalwart_enabled', false)) {

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -72,8 +72,11 @@ class ApiController extends Controller
   public function set(): JSONResponse
   {
     $params = $this->request->getParams();
-    $name = strval($params['name']);
-    $token = strval($params['token']);
+    $name = strval($params['name'] ?? '');
+    $token = strval($params['token'] ?? '');
+    if ($name === '' || $token === '') {
+      return new JSONResponse(['success' => false], Http::STATUS_BAD_REQUEST);
+    }
     try {
       $imapManager = $this->imapManagerMapper->set($this->userId, $token, $name);
     } catch (\InvalidArgumentException $e) {
@@ -90,18 +93,18 @@ class ApiController extends Controller
   public function setSync(): JSONResponse
   {
     $params = $this->request->getParams();
-    $frequency = strval($params['frequency']);
+    $frequency = strval($params['frequency'] ?? '');
     if (!in_array($frequency, ['daily', 'hourly', 'minutely'], true)) {
       return new JSONResponse(['success' => false], Http::STATUS_BAD_REQUEST);
     }
-    $primary = strval($params['primary']);
+    $primary = strval($params['primary'] ?? '');
     if (!in_array($primary, ['sunet', 'm365'], true)) {
       return new JSONResponse(['success' => false], Http::STATUS_BAD_REQUEST);
     }
-    $calendar  = boolval($params['calendar']);
-    $contacts  = boolval($params['contacts']);
-    $email     = boolval($params['email']);
-    $enabled   = boolval($params['enabled']);
+    $calendar  = boolval($params['calendar'] ?? false);
+    $contacts  = boolval($params['contacts'] ?? false);
+    $email     = boolval($params['email'] ?? false);
+    $enabled   = boolval($params['enabled'] ?? false);
     try {
       $syncManager = $this->syncManagerMapper->set($this->userId, $frequency, $calendar, $contacts, $email, $primary, $enabled);
     } catch (\InvalidArgumentException $e) {

--- a/lib/Migration/Version00500Date20260417000000.php
+++ b/lib/Migration/Version00500Date20260417000000.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Micke Nordin <kano@sunet.se>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\ImapManager\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version00500Date20260417000000 extends SimpleMigrationStep
+{
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options)
+    {
+        /** @var ISchemaWrapper $schema */
+        $schema = $schemaClosure();
+        $table_name = 'imap_manager_users';
+
+        if (!$schema->hasTable($table_name)) {
+            return null;
+        }
+        $table = $schema->getTable($table_name);
+        $name_column = $table->getColumn('name');
+        if ($name_column->getLength() > 255) {
+            $name_column->setLength(255);
+        }
+        if (!$table->hasIndex('imap_mgr_user_name_uq')) {
+            $table->addUniqueIndex(['user_id', 'name'], 'imap_mgr_user_name_uq');
+        }
+        return $schema;
+    }
+}

--- a/lib/Migration/Version00500Date20260417000000.php
+++ b/lib/Migration/Version00500Date20260417000000.php
@@ -11,12 +11,17 @@ namespace OCA\ImapManager\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\IDBConnection;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 class Version00500Date20260417000000 extends SimpleMigrationStep
 {
-    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options)
+    public function __construct(
+        private IDBConnection $connection,
+    ) {}
+
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
         /** @var ISchemaWrapper $schema */
         $schema = $schemaClosure();
@@ -25,14 +30,56 @@ class Version00500Date20260417000000 extends SimpleMigrationStep
         if (!$schema->hasTable($table_name)) {
             return null;
         }
+
+        [$has_oversize, $has_duplicates] = $this->inspectExistingData($table_name);
+
         $table = $schema->getTable($table_name);
         $name_column = $table->getColumn('name');
-        if ($name_column->getLength() > 255) {
+
+        if ($has_oversize) {
+            $output->warning(
+                'imap_manager: existing rows in imap_manager_users have name > 255 chars; '
+                . 'leaving name column at its current length. Clean up manually before a future migration shrinks it.'
+            );
+        } elseif ($name_column->getLength() > 255) {
             $name_column->setLength(255);
         }
-        if (!$table->hasIndex('imap_mgr_user_name_uq')) {
+
+        if ($has_duplicates) {
+            $output->warning(
+                'imap_manager: duplicate (user_id, name) rows exist in imap_manager_users; '
+                . 'skipping unique index creation. Deduplicate manually, then re-run the migration.'
+            );
+        } elseif (!$table->hasIndex('imap_mgr_user_name_uq')) {
             $table->addUniqueIndex(['user_id', 'name'], 'imap_mgr_user_name_uq');
         }
+
         return $schema;
+    }
+
+    /**
+     * @return array{0: bool, 1: bool} [hasOversize, hasDuplicates]
+     */
+    private function inspectExistingData(string $table_name): array
+    {
+        $qb = $this->connection->getQueryBuilder();
+        $qb->select('user_id', 'name')->from($table_name);
+        $result = $qb->executeQuery();
+
+        $has_oversize = false;
+        $has_duplicates = false;
+        $seen = [];
+        while ($row = $result->fetch()) {
+            if (strlen((string)$row['name']) > 255) {
+                $has_oversize = true;
+            }
+            $key = $row['user_id'] . "\0" . $row['name'];
+            if (isset($seen[$key])) {
+                $has_duplicates = true;
+            }
+            $seen[$key] = true;
+        }
+        $result->closeCursor();
+        return [$has_oversize, $has_duplicates];
     }
 }

--- a/lib/Service/StalwartService.php
+++ b/lib/Service/StalwartService.php
@@ -46,7 +46,12 @@ class StalwartService
         $response = $client->$method($url, $options);
         $statusCode = $response->getStatusCode();
         if ($statusCode < 200 || $statusCode >= 300) {
-            throw new \RuntimeException('Stalwart API returned HTTP ' . $statusCode);
+            throw new \RuntimeException(sprintf(
+                'Stalwart API %s %s returned HTTP %d',
+                strtoupper($method),
+                $path,
+                $statusCode
+            ));
         }
         $responseBody = $response->getBody();
         return json_decode($responseBody, true) ?? [];

--- a/lib/Service/StalwartService.php
+++ b/lib/Service/StalwartService.php
@@ -44,6 +44,10 @@ class StalwartService
             $options['body'] = json_encode($body);
         }
         $response = $client->$method($url, $options);
+        $statusCode = $response->getStatusCode();
+        if ($statusCode < 200 || $statusCode >= 300) {
+            throw new \RuntimeException('Stalwart API returned HTTP ' . $statusCode);
+        }
         $responseBody = $response->getBody();
         return json_decode($responseBody, true) ?? [];
     }
@@ -87,8 +91,7 @@ class StalwartService
     public function testConnection(): bool
     {
         try {
-            $adminUser = $this->appConfig->getValueString('imap_manager', 'stalwart_admin_user', 'admin');
-            $this->request('get', '/api/principal/' . urlencode($adminUser));
+            $this->request('get', '/api/principal');
             return true;
         } catch (\Exception $e) {
             $this->logger->warning('Stalwart connection test failed: ' . $e->getMessage());

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@nextcloud/axios": "^2.5.1",
         "@nextcloud/dialogs": "^7.0.0-rc.0",
         "@nextcloud/l10n": "^3.1.0",
+        "@nextcloud/password-confirmation": "^6.1.0",
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/vue": "^9.0.0-rc.1",
         "uuid": "^11.1.0",
@@ -97,16 +98,15 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.1.tgz",
-      "integrity": "sha512-UnJfnIpc/+JO0/+KRVQNGU+y5taA5vCbwN8+azkX6beii/ZF+enZJSOKo11ZSzGJjlNfJHfQtmQT8H+9TXPG2w==",
-      "dev": true,
-      "peer": true,
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.1",
-        "@babel/types": "^7.27.1",
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25",
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
       },
       "engines": {
@@ -171,9 +171,10 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -203,11 +204,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.2.tgz",
-      "integrity": "sha512-QYLs8299NA7WM/bZAdp+CviYYkVoYXlDW2rzliy3chxd1PQjej7JORuMJDJXJUb9g0TT+B99EwaVLKmX+sPXWw==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.1"
+        "@babel/types": "^7.29.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -217,9 +219,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.1.tgz",
-      "integrity": "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -269,12 +272,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.1.tgz",
-      "integrity": "sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-validator-identifier": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -489,26 +493,29 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.0.tgz",
-      "integrity": "sha512-FRdBLykrPPA6P76GGGqlex/e7fbe0F1ykgxHYNXQsH/iTEtjMj/f9bpY5oQqbjt5VgZvgz/uKXbGuROijh3VLA==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.9"
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.0.tgz",
-      "integrity": "sha512-lGTor4VlXcesUMh1cupTUTDoCxMb0V6bm3CnxHzQcw8Eaf1jQbgQX4i02fYgT0vJ82tb5MZ4CZk1LRGkktJCzg==",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.0",
-        "@floating-ui/utils": "^0.2.9"
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
-      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -572,36 +579,29 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
-      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
-      "dev": true,
-      "peer": true,
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
       "dependencies": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -618,16 +618,16 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-      "dev": true,
-      "peer": true,
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -715,39 +715,27 @@
         "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
       }
     },
-    "node_modules/@nextcloud/auth/node_modules/@nextcloud/browser-storage": {
+    "node_modules/@nextcloud/axios": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@nextcloud/axios/-/axios-2.5.2.tgz",
+      "integrity": "sha512-8frJb77jNMbz00TjsSqs1PymY0nIEbNM4mVmwen2tXY7wNgRai6uXilIlXKOYB9jR/F/HKRj6B4vUwVwZbhdbw==",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@nextcloud/auth": "^2.5.1",
+        "@nextcloud/router": "^3.0.1",
+        "axios": "^1.12.2"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+      }
+    },
+    "node_modules/@nextcloud/browser-storage": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@nextcloud/browser-storage/-/browser-storage-0.5.0.tgz",
       "integrity": "sha512-usYr4GlJQlK3hgZURvklqWb9ivi7sgsSuFqXrs7s4hl1LTS4enzPrnkQumm6nRsQruf0ITS+OBsK+oELEbvYPA==",
       "license": "GPL-3.0-or-later",
       "engines": {
         "node": "^24 || ^22 || ^20"
-      }
-    },
-    "node_modules/@nextcloud/axios": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/axios/-/axios-2.5.1.tgz",
-      "integrity": "sha512-AA7BPF/rsOZWAiVxqlobGSdD67AEwjOnymZCKUIwEIBArKxYK7OQEqcILDjQwgj6G0e/Vg9Y8zTVsPZp+mlvwA==",
-      "dependencies": {
-        "@nextcloud/auth": "^2.3.0",
-        "@nextcloud/router": "^3.0.1",
-        "axios": "^1.6.8"
-      },
-      "engines": {
-        "node": "^20.0.0",
-        "npm": "^10.0.0"
-      }
-    },
-    "node_modules/@nextcloud/browser-storage": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/browser-storage/-/browser-storage-0.4.0.tgz",
-      "integrity": "sha512-D6XxznxCYmJ3oBCC3p0JB6GZJ2RZ9dgbB1UqtTePXrIvHUMBAeF/YkiGKYxLAVZCZb+NSNZXgAYHm/3LnIUbDg==",
-      "dependencies": {
-        "core-js": "3.37.0"
-      },
-      "engines": {
-        "node": "^20.0.0",
-        "npm": "^10.0.0"
       }
     },
     "node_modules/@nextcloud/capabilities": {
@@ -802,16 +790,16 @@
       }
     },
     "node_modules/@nextcloud/event-bus": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.3.2.tgz",
-      "integrity": "sha512-1Qfs6i7Tz2qd1A33NpBQOt810ydHIRjhyXMFwSEkYX2yUI80lAk/sWO8HIB2Fqp+iffhyviPPcQYoytMDRyDNw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.3.3.tgz",
+      "integrity": "sha512-zIfvKmUGkXpVzRKoXrcO9hkoiKDm65fqNxy/XIbIxrQhZByPq3gDkjBpnu3V5Gs8JdYwa73R8DjzV9oH8HYhIg==",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@types/semver": "^7.5.8",
-        "semver": "^7.6.3"
+        "@types/semver": "^7.7.0",
+        "semver": "^7.7.2"
       },
       "engines": {
-        "node": "^20.0.0",
-        "npm": "^10.0.0"
+        "node": "^20 || ^22 || ^24"
       }
     },
     "node_modules/@nextcloud/event-bus/node_modules/semver": {
@@ -918,6 +906,24 @@
         "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
       }
     },
+    "node_modules/@nextcloud/password-confirmation": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/password-confirmation/-/password-confirmation-6.1.0.tgz",
+      "integrity": "sha512-N2ChXDbPcUcQCoAjj1yc65zfc61yiKpdM3qm/y3Y/y//NG7XWNNINwBg85lqJ2SISgmVStpsQ1d0blpFCoQXkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@nextcloud/auth": "^2.5.3",
+        "@nextcloud/axios": "^2.5.2",
+        "@nextcloud/l10n": "^3.4.1",
+        "@nextcloud/logger": "^3.0.3",
+        "@nextcloud/router": "^3.1.0",
+        "@nextcloud/vue": "^9.6.0",
+        "vue": "^3.5.30"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+      }
+    },
     "node_modules/@nextcloud/paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@nextcloud/paths/-/paths-2.2.1.tgz",
@@ -951,17 +957,6 @@
         "npm": "^10.0.0"
       }
     },
-    "node_modules/@nextcloud/timezones": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/timezones/-/timezones-0.2.0.tgz",
-      "integrity": "sha512-1mwQ+asTFOgv9rxPoAMEbDF8JfnenIa2EGNS+8MATCyi6WXxYh0Lhkaq1d3l2+xNbUPHgMnk4cRYsvIo319lkA==",
-      "dependencies": {
-        "ical.js": "^2.1.0"
-      },
-      "engines": {
-        "node": "^20 || ^22"
-      }
-    },
     "node_modules/@nextcloud/typings": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@nextcloud/typings/-/typings-1.10.0.tgz",
@@ -975,56 +970,149 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "9.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.0.0-rc.1.tgz",
-      "integrity": "sha512-FNWqpmRErjNDMAQiTxpvm+IS1A4Pn4YCvCXBtjgJLmDYnuk9WGIDubolbVNZtji36A1YdkatJIfI1Om3IKntmQ==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.6.0.tgz",
+      "integrity": "sha512-RZuMnrNwzajx3AbJcGHC49NUORSPHMRbzhHCBlR0Z5N3BvUmy5d7MPVTqsmJXiO5emSCTanJ+rwDeo6HTAX3ng==",
+      "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",
-        "@floating-ui/dom": "^1.6.13",
-        "@nextcloud/auth": "^2.4.0",
-        "@nextcloud/axios": "^2.5.1",
-        "@nextcloud/browser-storage": "^0.4.0",
-        "@nextcloud/capabilities": "^1.2.0",
-        "@nextcloud/event-bus": "^3.3.2",
-        "@nextcloud/initial-state": "^2.2.0",
-        "@nextcloud/l10n": "^3.2.0",
-        "@nextcloud/logger": "^3.0.2",
-        "@nextcloud/router": "^3.0.1",
-        "@nextcloud/sharing": "^0.2.4",
-        "@nextcloud/timezones": "^0.2.0",
-        "@vuepic/vue-datepicker": "^11.0.2",
-        "@vueuse/components": "^13.0.0",
-        "@vueuse/core": "^13.0.0",
+        "@floating-ui/dom": "^1.7.6",
+        "@nextcloud/auth": "^2.5.3",
+        "@nextcloud/axios": "^2.5.2",
+        "@nextcloud/browser-storage": "^0.5.0",
+        "@nextcloud/capabilities": "^1.2.1",
+        "@nextcloud/event-bus": "^3.3.3",
+        "@nextcloud/initial-state": "^3.0.0",
+        "@nextcloud/l10n": "^3.4.1",
+        "@nextcloud/logger": "^3.0.3",
+        "@nextcloud/router": "^3.1.0",
+        "@nextcloud/sharing": "^0.4.0",
+        "@vuepic/vue-datepicker": "^11.0.3",
+        "@vueuse/components": "^14.2.1",
+        "@vueuse/core": "^14.2.1",
         "blurhash": "^2.0.5",
         "clone": "^2.1.2",
-        "debounce": "^2.2.0",
-        "dompurify": "^3.2.4",
-        "emoji-mart-vue-fast": "^15.0.4",
+        "debounce": "^3.0.0",
+        "dompurify": "^3.3.3",
+        "emoji-mart-vue-fast": "^15.0.5",
         "escape-html": "^1.0.3",
         "floating-vue": "^5.2.2",
-        "focus-trap": "^7.6.4",
-        "linkifyjs": "^4.2.0",
-        "p-queue": "^8.0.1",
+        "focus-trap": "^8.0.0",
+        "linkifyjs": "^4.3.2",
+        "p-queue": "^9.1.0",
         "rehype-external-links": "^3.0.0",
         "rehype-highlight": "^7.0.2",
         "rehype-react": "^8.0.0",
         "remark-breaks": "^4.0.0",
         "remark-parse": "^11.0.0",
-        "remark-rehype": "^11.1.1",
-        "splitpanes": "^4.0.3",
+        "remark-rehype": "^11.1.2",
+        "remark-stringify": "^11.0.0",
+        "remark-unlink-protocols": "^1.0.0",
+        "splitpanes": "^4.0.4",
         "striptags": "^3.2.0",
-        "tabbable": "^6.2.0",
+        "tabbable": "^6.4.0",
         "tributejs": "^5.1.3",
+        "ts-md5": "^2.0.1",
         "unified": "^11.0.5",
         "unist-builder": "^4.0.0",
-        "unist-util-visit": "^5.0.0",
-        "vue": "^3.5.13",
-        "vue-router": "^4.5.0",
+        "unist-util-visit": "^5.1.0",
+        "vue": "^3.5.18",
+        "vue-router": "^5.0.3",
         "vue-select": "^4.0.0-beta.6"
       },
       "engines": {
-        "node": "^20.11.0 || ^22",
-        "npm": "^10 || ^11"
+        "node": "^20.11.0 || ^22 || ^24"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@nextcloud/initial-state": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-3.0.0.tgz",
+      "integrity": "sha512-cV+HBdkQJGm8FxkBI5rFT/FbMNWNBvpbj6OPrg4Ae4YOOsQ15CL8InPOAw1t4XkOkQK2NEdUGQLVUz/19wXbdQ==",
+      "license": "GPL-3.0-or-later",
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@nextcloud/sharing": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-0.4.0.tgz",
+      "integrity": "sha512-1hUNyc7uJdBpnimOnEshJjEtAPAjzDYVl6qmWqF5ZxoN9wOvbExw0QjX3xFIbHbX2dmvbRNLBj0RzLzipmZyeg==",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@nextcloud/initial-state": "^3.0.0",
+        "is-svg": "^6.1.0"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+      },
+      "optionalDependencies": {
+        "@nextcloud/files": "^3.12.2 || ^4.0.0"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@vueuse/core": {
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.2.1.tgz",
+      "integrity": "sha512-3vwDzV+GDUNpdegRY6kzpLm4Igptq+GA0QkJ3W61Iv27YWwW/ufSlOfgQIpN6FZRMG0mkaz4gglJRtq5SeJyIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "14.2.1",
+        "@vueuse/shared": "14.2.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@vueuse/metadata": {
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.2.1.tgz",
+      "integrity": "sha512-1ButlVtj5Sb/HDtIy1HFr1VqCP4G6Ypqt5MAo0lCgjokrk2mvQKsK2uuy0vqu/Ks+sHfuHo0B9Y9jn9xKdjZsw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@vueuse/shared": {
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.2.1.tgz",
+      "integrity": "sha512-shTJncjV9JTI4oVNyF1FQonetYAiTBd+Qj7cY89SWbXSkx7gyhrgtEdF2ZAVWS1S3SHlaROO6F2IesJxQEkZBw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/p-queue": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.2.tgz",
+      "integrity": "sha512-ktsDOALzTYTWWF1PbkNVg2rOt+HaOaMWJMUnt7T3qf5tvZ1L8dBW3tObzprBcXNMKkwj+yFSLqHso0x+UFcJXw==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@nextcloud/webpack-vue-config": {
@@ -1676,106 +1764,165 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="
     },
-    "node_modules/@vue/compiler-core": {
-      "version": "3.5.14",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.14.tgz",
-      "integrity": "sha512-k7qMHMbKvoCXIxPhquKQVw3Twid3Kg4s7+oYURxLGRd56LiuHJVrvFKI4fm2AM3c8apqODPfVJGoh8nePbXMRA==",
+    "node_modules/@vue-macros/common": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@vue-macros/common/-/common-3.1.2.tgz",
+      "integrity": "sha512-h9t4ArDdniO9ekYHAD95t9AZcAbb19lEGK+26iAjUODOIJKmObDNBSe4+6ELQAA3vtYiFPPBtHh7+cQCKi3Dng==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.2",
-        "@vue/shared": "3.5.14",
-        "entities": "^4.5.0",
+        "@vue/compiler-sfc": "^3.5.22",
+        "ast-kit": "^2.1.2",
+        "local-pkg": "^1.1.2",
+        "magic-string-ast": "^1.0.2",
+        "unplugin-utils": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/vue-macros"
+      },
+      "peerDependencies": {
+        "vue": "^2.7.0 || ^3.2.25"
+      },
+      "peerDependenciesMeta": {
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.32.tgz",
+      "integrity": "sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.2",
+        "@vue/shared": "3.5.32",
+        "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.14",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.14.tgz",
-      "integrity": "sha512-1aOCSqxGOea5I80U2hQJvXYpPm/aXo95xL/m/mMhgyPUsKe9jhjwWpziNAw7tYRnbz1I61rd9Mld4W9KmmRoug==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.32.tgz",
+      "integrity": "sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.14",
-        "@vue/shared": "3.5.14"
+        "@vue/compiler-core": "3.5.32",
+        "@vue/shared": "3.5.32"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.14",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.14.tgz",
-      "integrity": "sha512-9T6m/9mMr81Lj58JpzsiSIjBgv2LiVoWjIVa7kuXHICUi8LiDSIotMpPRXYJsXKqyARrzjT24NAwttrMnMaCXA==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.32.tgz",
+      "integrity": "sha512-8UYUYo71cP/0YHMO814TRZlPuUUw3oifHuMR7Wp9SNoRSrxRQnhMLNlCeaODNn6kNTJsjFoQ/kqIj4qGvya4Xg==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.2",
-        "@vue/compiler-core": "3.5.14",
-        "@vue/compiler-dom": "3.5.14",
-        "@vue/compiler-ssr": "3.5.14",
-        "@vue/shared": "3.5.14",
+        "@babel/parser": "^7.29.2",
+        "@vue/compiler-core": "3.5.32",
+        "@vue/compiler-dom": "3.5.32",
+        "@vue/compiler-ssr": "3.5.32",
+        "@vue/shared": "3.5.32",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.17",
-        "postcss": "^8.5.3",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.8",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.14",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.14.tgz",
-      "integrity": "sha512-Y0G7PcBxr1yllnHuS/NxNCSPWnRGH4Ogrp0tsLA5QemDZuJLs99YjAKQ7KqkHE0vCg4QTKlQzXLKCMF7WPSl7Q==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.32.tgz",
+      "integrity": "sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.14",
-        "@vue/shared": "3.5.14"
+        "@vue/compiler-dom": "3.5.32",
+        "@vue/shared": "3.5.32"
       }
     },
     "node_modules/@vue/devtools-api": {
-      "version": "6.6.4",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
-      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g=="
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-8.1.1.tgz",
+      "integrity": "sha512-bsDMJ07b3GN1puVwJb/fyFnj/U2imyswK5UQVLZwVl7O05jDrt6BHxeG5XffmOOdasOj/bOmIjxJvGPxU7pcqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^8.1.1"
+      }
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.1.1.tgz",
+      "integrity": "sha512-gVBaBv++i+adg4JpH71k9ppl4soyR7Y2McEqO5YNgv0BI1kMZ7BDX5gnwkZ5COYgiCyhejZG+yGNrBAjj6Coqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^8.1.1",
+        "birpc": "^2.6.1",
+        "hookable": "^5.5.3",
+        "perfect-debounce": "^2.0.0"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.1.1.tgz",
+      "integrity": "sha512-+h4ttmJYl/txpxHKaoZcaKpC+pvckgLzIDiSQlaQ7kKthKh8KuwoLW2D8hPJEnqKzXOvu15UHEoGyngAXCz0EQ==",
+      "license": "MIT"
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.5.14",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.14.tgz",
-      "integrity": "sha512-7cK1Hp343Fu/SUCCO52vCabjvsYu7ZkOqyYu7bXV9P2yyfjUMUXHZafEbq244sP7gf+EZEz+77QixBTuEqkQQw==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.32.tgz",
+      "integrity": "sha512-/ORasxSGvZ6MN5gc+uE364SxFdJ0+WqVG0CENXaGW58TOCdrAW76WWaplDtECeS1qphvtBZtR+3/o1g1zL4xPQ==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.5.14"
+        "@vue/shared": "3.5.32"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.5.14",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.14.tgz",
-      "integrity": "sha512-w9JWEANwHXNgieAhxPpEpJa+0V5G0hz3NmjAZwlOebtfKyp2hKxKF0+qSh0Xs6/PhfGihuSdqMprMVcQU/E6ag==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.32.tgz",
+      "integrity": "sha512-pDrXCejn4UpFDFmMd27AcJEbHaLemaE5o4pbb7sLk79SRIhc6/t34BQA7SGNgYtbMnvbF/HHOftYBgFJtUoJUQ==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.14",
-        "@vue/shared": "3.5.14"
+        "@vue/reactivity": "3.5.32",
+        "@vue/shared": "3.5.32"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.5.14",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.14.tgz",
-      "integrity": "sha512-lCfR++IakeI35TVR80QgOelsUIdcKjd65rWAMfdSlCYnaEY5t3hYwru7vvcWaqmrK+LpI7ZDDYiGU5V3xjMacw==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.32.tgz",
+      "integrity": "sha512-1CDVv7tv/IV13V8Nip1k/aaObVbWqRlVCVezTwx3K07p7Vxossp5JU1dcPNhJk3w347gonIUT9jQOGutyJrSVQ==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.14",
-        "@vue/runtime-core": "3.5.14",
-        "@vue/shared": "3.5.14",
-        "csstype": "^3.1.3"
+        "@vue/reactivity": "3.5.32",
+        "@vue/runtime-core": "3.5.32",
+        "@vue/shared": "3.5.32",
+        "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.5.14",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.14.tgz",
-      "integrity": "sha512-Rf/ISLqokIvcySIYnv3tNWq40PLpNLDLSJwwVWzG6MNtyIhfbcrAxo5ZL9nARJhqjZyWWa40oRb2IDuejeuv6w==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.32.tgz",
+      "integrity": "sha512-IOjm2+JQwRFS7W28HNuJeXQle9KdZbODFY7hFGVtnnghF51ta20EWAZJHX+zLGtsHhaU6uC9BGPV52KVpYryMQ==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.5.14",
-        "@vue/shared": "3.5.14"
+        "@vue/compiler-ssr": "3.5.32",
+        "@vue/shared": "3.5.32"
       },
       "peerDependencies": {
-        "vue": "3.5.14"
+        "vue": "3.5.32"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.14",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.14.tgz",
-      "integrity": "sha512-oXTwNxVfc9EtP1zzXAlSlgARLXNC84frFYkS0HHz0h3E4WZSP9sywqjqzGCP9Y34M8ipNmd380pVgmMuwELDyQ=="
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.32.tgz",
+      "integrity": "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==",
+      "license": "MIT"
     },
     "node_modules/@vuepic/vue-datepicker": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/@vuepic/vue-datepicker/-/vue-datepicker-11.0.2.tgz",
-      "integrity": "sha512-uHh78mVBXCEjam1uVfTzZ/HkyDwut/H6b2djSN9YTF+l/EA+XONfdCnOVSi1g+qVGSy65DcQAwyBNidAssnudQ==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@vuepic/vue-datepicker/-/vue-datepicker-11.0.3.tgz",
+      "integrity": "sha512-sb2adwqwK2PizLQOpxCYps2SwhVT6/ic2HMIOqHJXuYa6iAJZWGL5YVlS7O4aW+sk6ZyxlDURLO7kDZPL4HB/w==",
+      "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"
       },
@@ -1787,12 +1934,51 @@
       }
     },
     "node_modules/@vueuse/components": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/components/-/components-13.2.0.tgz",
-      "integrity": "sha512-H5xu7JGR/BqrflE6TofyBF7dqh5Iy/KQ0AQjZM0Mfn+U5U9wp8humqMzXCXGbTf2iza8s3hsaV6TvcUwlILxsQ==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/components/-/components-14.2.1.tgz",
+      "integrity": "sha512-wB0SvwJ22mNm1hWCMI1wTWz4x55nDTugT5RIg/KCwlWc1vITWL6ry5VTU3SQzsMD2XcazJK8Be1siIsrBb/Vcw==",
+      "license": "MIT",
       "dependencies": {
-        "@vueuse/core": "13.2.0",
-        "@vueuse/shared": "13.2.0"
+        "@vueuse/core": "14.2.1",
+        "@vueuse/shared": "14.2.1"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/@vueuse/components/node_modules/@vueuse/core": {
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.2.1.tgz",
+      "integrity": "sha512-3vwDzV+GDUNpdegRY6kzpLm4Igptq+GA0QkJ3W61Iv27YWwW/ufSlOfgQIpN6FZRMG0mkaz4gglJRtq5SeJyIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "14.2.1",
+        "@vueuse/shared": "14.2.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/@vueuse/components/node_modules/@vueuse/metadata": {
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.2.1.tgz",
+      "integrity": "sha512-1ButlVtj5Sb/HDtIy1HFr1VqCP4G6Ypqt5MAo0lCgjokrk2mvQKsK2uuy0vqu/Ks+sHfuHo0B9Y9jn9xKdjZsw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/components/node_modules/@vueuse/shared": {
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.2.1.tgz",
+      "integrity": "sha512-shTJncjV9JTI4oVNyF1FQonetYAiTBd+Qj7cY89SWbXSkx7gyhrgtEdF2ZAVWS1S3SHlaROO6F2IesJxQEkZBw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       },
       "peerDependencies": {
         "vue": "^3.5.0"
@@ -2096,7 +2282,6 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -2277,6 +2462,38 @@
         "util": "^0.12.5"
       }
     },
+    "node_modules/ast-kit": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.2.0.tgz",
+      "integrity": "sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.5",
+        "pathe": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/ast-walker-scope": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/ast-walker-scope/-/ast-walker-scope-0.8.3.tgz",
+      "integrity": "sha512-cbdCP0PGOBq0ASG+sjnKIoYkWMKhhz+F/h9pRexUdX2Hd38+WOlBkRKlqkGOSm0YQpcFMQBJeK4WspUAkwsEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.4",
+        "ast-kit": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2399,6 +2616,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/blurhash": {
@@ -3119,6 +3345,12 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/confbox": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+      "license": "MIT"
+    },
     "node_modules/connect-history-api-fallback": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
@@ -3191,10 +3423,11 @@
       "peer": true
     },
     "node_modules/core-js": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.0.tgz",
-      "integrity": "sha512-fu5vHevQ8ZG4og+LXug8ulUtVxjOcEYvifJr7L5Bfq9GOztVqsKd9/59hUk2ZSbCrS3BqUr3EpaYGIYzq7g3Ug==",
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
       "hasInstallScript": true,
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -3366,9 +3599,10 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
@@ -3382,17 +3616,19 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debounce": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.2.0.tgz",
-      "integrity": "sha512-Xks6RUDLZFdz8LIdR6q0MTH44k7FikOmnh5xkSjMig6ch45afc8sjTjRQf3P6ax8dMgcQrYO/AR2RGWURrruqw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-3.0.0.tgz",
+      "integrity": "sha512-64byRbF0/AirwbuHqB3/ZpMG9/nckDa6ZA0yd6UnaQNwbbemCOwvz2sL5sjXLHhZHADyiwLm0M5qMhltUUx+TA==",
+      "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3701,9 +3937,10 @@
       "peer": true
     },
     "node_modules/emoji-mart-vue-fast": {
-      "version": "15.0.4",
-      "resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-15.0.4.tgz",
-      "integrity": "sha512-OjuxqoMJRTTG7Vevz0mR1ZnqY1DI8gGnmoskuuC8qL8VwwTjrGdwAO4WRWtAUN8P6Di7kxvY6cUgNETNFmbP4A==",
+      "version": "15.0.5",
+      "resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-15.0.5.tgz",
+      "integrity": "sha512-wnxLor8ggpqshoOPwIc33MdOC3A1XFeDLgUwYLPtNPL8VeAtXJAVrnFq1CN5PeCYAFoLo4IufHQZ9CfHD4IZiw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "core-js": "^3.23.5"
@@ -3738,9 +3975,10 @@
       }
     },
     "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
       },
@@ -4022,7 +4260,8 @@
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -4160,6 +4399,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/exsolve": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
+      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "license": "MIT"
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -4415,11 +4660,12 @@
       }
     },
     "node_modules/focus-trap": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.4.tgz",
-      "integrity": "sha512-xx560wGBk7seZ6y933idtjJQc1l+ck+pI3sKvhKozdBV1dRZoKhkW5xoCaFv9tQiX5RH1xfSxjuNu6g+lmN/gw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-8.0.1.tgz",
+      "integrity": "sha512-9ptSG6z51YQOstI/oN4XuVGP/03u2nh0g//qz7L6zX0i6PZiPnkcf3GenXq7N2hZnASXaMxTPpbKwdI+PFvxlw==",
+      "license": "MIT",
       "dependencies": {
-        "tabbable": "^6.2.0"
+        "tabbable": "^6.4.0"
       }
     },
     "node_modules/follow-redirects": {
@@ -4804,6 +5050,12 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "license": "MIT"
+    },
     "node_modules/hot-patcher": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/hot-patcher/-/hot-patcher-2.0.1.tgz",
@@ -4962,11 +5214,6 @@
       "engines": {
         "node": ">=10.18"
       }
-    },
-    "node_modules/ical.js": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.1.0.tgz",
-      "integrity": "sha512-BOVfrH55xQ6kpS3muGvIXIg2l7p+eoe12/oS7R5yrO3TL/j/bLsR0PR+tYQESFbyTbvGgPHn9zQ6tI4FWyuSaQ=="
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -5508,8 +5755,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
-      "peer": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -5539,8 +5784,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
-      "peer": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -5617,6 +5860,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/local-pkg": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.2.tgz",
+      "integrity": "sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==",
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.4",
+        "pkg-types": "^2.3.0",
+        "quansync": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -5680,11 +5940,27 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magic-string-ast": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/magic-string-ast/-/magic-string-ast-1.0.3.tgz",
+      "integrity": "sha512-CvkkH1i81zl7mmb94DsRiFeG9V2fR2JeuK8yDgS8oiZSFa++wWLEgZ5ufEOyLHbvSbD1gTRKv9NdX69Rnvr9JA==",
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.19"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
       }
     },
     "node_modules/material-colors": {
@@ -5720,6 +5996,20 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/mdast-squeeze-paragraphs": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-squeeze-paragraphs/-/mdast-squeeze-paragraphs-6.0.0.tgz",
+      "integrity": "sha512-6NDbJPTg0M0Ye+TlYwX1KJ1LFbp515P2immRJyJQhc9Na9cetHzSoHNYIQcXpANEAP1sm9yd/CTZU2uHqR5A+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mdast-util-find-and-replace": {
@@ -6480,10 +6770,45 @@
         "node": "*"
       }
     },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "license": "MIT"
+    },
+    "node_modules/mlly/node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/muggle-string": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+      "license": "MIT"
     },
     "node_modules/multicast-dns": {
       "version": "7.2.5",
@@ -7030,6 +7355,12 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "license": "MIT"
+    },
     "node_modules/pbkdf2": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.5.tgz",
@@ -7048,6 +7379,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/perfect-debounce": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
+      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -7137,6 +7474,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/pkg-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
+      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.2.2",
+        "exsolve": "^1.0.7",
+        "pathe": "^2.0.3"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -7148,9 +7496,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -7165,8 +7513,9 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7402,6 +7751,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/quansync": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
+      "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/antfu"
+        },
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/sxzz"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/querystring-es3": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
@@ -7632,6 +7997,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-unlink-protocols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/remark-unlink-protocols/-/remark-unlink-protocols-1.0.0.tgz",
+      "integrity": "sha512-5j/F28jhFmxeyz8nuJYYIWdR4nNpKWZ8A+tVwnK/0pq7Rjue33CINEYSckSq2PZvedhKUwbn08qyiuGoPLBung==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-squeeze-paragraphs": "^6.0.0",
+        "unist-util-visit": "^5.0.0"
       }
     },
     "node_modules/require-from-string": {
@@ -7977,6 +8368,12 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/scule": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/scule/-/scule-1.3.0.tgz",
+      "integrity": "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==",
+      "license": "MIT"
     },
     "node_modules/select-hose": {
       "version": "2.0.0",
@@ -8458,9 +8855,10 @@
       }
     },
     "node_modules/splitpanes": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/splitpanes/-/splitpanes-4.0.3.tgz",
-      "integrity": "sha512-S/f1CoH2JroOib7kzQtTQNtQCa7VzNQ2qKOO5HNj/5EVVcNkfz1eX/sH+X3XKdBdDLihEKDekVGwrLADd2oirA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/splitpanes/-/splitpanes-4.0.4.tgz",
+      "integrity": "sha512-RbysugZhjbCw5fgplvk3hOXr41stahQDtZhHVkhnnJI6H4wlGDhM2kIpbehy7v92duy9GnMa8zIhHigIV1TWtg==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antoniandre"
       },
@@ -8659,9 +9057,10 @@
       }
     },
     "node_modules/tabbable": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.2",
@@ -8763,6 +9162,51 @@
       },
       "engines": {
         "node": ">=0.6.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/to-buffer": {
@@ -8891,6 +9335,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/ts-md5": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ts-md5/-/ts-md5-2.0.1.tgz",
+      "integrity": "sha512-yF35FCoEOFBzOclSkMNEUbFQZuv89KEQ+5Xz03HrMSGUGB1+r+El+JiGOFwsP4p9RFNzwlrydYoTLvPOuICl9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -8965,6 +9418,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/typescript-event-target/-/typescript-event-target-1.1.1.tgz",
       "integrity": "sha512-dFSOFBKV6uwaloBCCUhxlD3Pr/P1a/tJdcmPrTXCHlEFD3faj0mztjcGn6VBAhQ0/Bdy8K3VWrrqwbt/ffsYsg=="
+    },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
@@ -9053,9 +9512,10 @@
       }
     },
     "node_modules/unist-util-visit": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
-      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-is": "^6.0.0",
@@ -9087,6 +9547,60 @@
       "peer": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/unplugin": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.0.0.tgz",
+      "integrity": "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "picomatch": "^4.0.3",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/unplugin-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.1.tgz",
+      "integrity": "sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog==",
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/unplugin-utils/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/unplugin/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -9254,15 +9768,16 @@
       "peer": true
     },
     "node_modules/vue": {
-      "version": "3.5.14",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.14.tgz",
-      "integrity": "sha512-LbOm50/vZFG6Mhy6KscQYXZMQ0LMCC/y40HDJPPvGFQ+i/lUH+PJHR6C3assgOQiXdl6tAfsXHbXYVBZZu65ew==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.32.tgz",
+      "integrity": "sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.14",
-        "@vue/compiler-sfc": "3.5.14",
-        "@vue/runtime-dom": "3.5.14",
-        "@vue/server-renderer": "3.5.14",
-        "@vue/shared": "3.5.14"
+        "@vue/compiler-dom": "3.5.32",
+        "@vue/compiler-sfc": "3.5.32",
+        "@vue/runtime-dom": "3.5.32",
+        "@vue/server-renderer": "3.5.32",
+        "@vue/shared": "3.5.32"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -9348,17 +9863,88 @@
       }
     },
     "node_modules/vue-router": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.1.tgz",
-      "integrity": "sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.0.4.tgz",
+      "integrity": "sha512-lCqDLCI2+fKVRl2OzXuzdSWmxXFLQRxQbmHugnRpTMyYiT+hNaycV0faqG5FBHDXoYrZ6MQcX87BvbY8mQ20Bg==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/devtools-api": "^6.6.4"
+        "@babel/generator": "^7.28.6",
+        "@vue-macros/common": "^3.1.1",
+        "@vue/devtools-api": "^8.0.6",
+        "ast-walker-scope": "^0.8.3",
+        "chokidar": "^5.0.0",
+        "json5": "^2.2.3",
+        "local-pkg": "^1.1.2",
+        "magic-string": "^0.30.21",
+        "mlly": "^1.8.0",
+        "muggle-string": "^0.4.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "scule": "^1.3.0",
+        "tinyglobby": "^0.2.15",
+        "unplugin": "^3.0.0",
+        "unplugin-utils": "^0.3.1",
+        "yaml": "^2.8.2"
       },
       "funding": {
         "url": "https://github.com/sponsors/posva"
       },
       "peerDependencies": {
-        "vue": "^3.2.0"
+        "@pinia/colada": ">=0.21.2",
+        "@vue/compiler-sfc": "^3.5.17",
+        "pinia": "^3.0.4",
+        "vue": "^3.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@pinia/colada": {
+          "optional": true
+        },
+        "@vue/compiler-sfc": {
+          "optional": true
+        },
+        "pinia": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-router/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/vue-router/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vue-router/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/vue-select": {
@@ -9730,6 +10316,12 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+      "license": "MIT"
+    },
     "node_modules/webpack/node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -9890,6 +10482,21 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@nextcloud/axios": "^2.5.1",
     "@nextcloud/dialogs": "^7.0.0-rc.0",
     "@nextcloud/l10n": "^3.1.0",
+    "@nextcloud/password-confirmation": "^6.1.0",
     "@nextcloud/router": "^3.0.1",
     "@nextcloud/vue": "^9.0.0-rc.1",
     "uuid": "^11.1.0",

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -85,6 +85,11 @@ import {
 
 import axios from "@nextcloud/axios";
 import { generateUrl } from "@nextcloud/router";
+import {
+  confirmPassword,
+  isPasswordConfirmationRequired,
+} from "@nextcloud/password-confirmation";
+import "@nextcloud/password-confirmation/style.css";
 
 export default {
   name: "AdminSettings",
@@ -128,6 +133,9 @@ export default {
 
     async save() {
       const url = generateUrl("/apps/imap_manager/admin/config");
+      if (isPasswordConfirmationRequired()) {
+        await confirmPassword();
+      }
       await axios.post(url, {
         dovecot_enabled: this.dovecotEnabled,
         stalwart_enabled: this.stalwartEnabled,

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -376,23 +376,9 @@ export default {
         this.isCopied = false;
       }, 2000);
     },
-    async csrfRequest(incoming_url, method, payload) {
-      let csrf_url = generateUrl("/csrftoken");
-      let csrfresult = await axios.get(csrf_url);
-      console.log("CSRF token loaded");
-      let csrftoken = csrfresult.data.token;
-      let url = generateUrl(incoming_url);
-      let result = await axios({
-        method: method,
-        url: url,
-        data: payload,
-        headers: { csrftoken },
-      });
-      return result;
-    },
     async get() {
-      let url = "/apps/imap_manager/get";
-      let result = await this.csrfRequest(url, "GET");
+      let url = generateUrl("/apps/imap_manager/get");
+      let result = await axios.get(url);
       if ("ids" in result.data) {
         this.tokens = result.data.ids;
       }
@@ -429,10 +415,10 @@ export default {
         return;
       }
       this.token = uuidv4();
-      let url = "/apps/imap_manager/set";
+      let url = generateUrl("/apps/imap_manager/set");
 
       let params = { token: this.token, name: this.name };
-      let result = await this.csrfRequest(url, "POST", params);
+      let result = await axios.post(url, params);
       if (result.data.success == true) {
         console.log("New IMAP password set");
         this.showDialog = true;
@@ -445,7 +431,7 @@ export default {
     },
     async set_sync() {
       // TODO: Implement delete of sync job
-      let url = "/apps/imap_manager/set_sync";
+      let url = generateUrl("/apps/imap_manager/set_sync");
       var selection = document.getElementById("select_options");
       var frequency = this.optionsValue;
       for (var i = 0; i < selection.children.length; i++) {
@@ -470,7 +456,7 @@ export default {
         primary: primary,
       };
       console.log(params);
-      let result = await this.csrfRequest(url, "POST", params);
+      let result = await axios.post(url, params);
       if (result.data.success == true) {
         console.log("New sync job set");
         if (this.syncActive) {
@@ -484,9 +470,9 @@ export default {
       }
     },
     async unset(id) {
-      let url = "/apps/imap_manager/delete";
+      let url = generateUrl("/apps/imap_manager/delete");
       let params = { id: id };
-      let result = await this.csrfRequest(url, "POST", params);
+      let result = await axios.post(url, params);
       if (result.data.success == true) {
         for (var i = 0; i < this.tokens.length; i++) {
           var token = this.tokens[i];
@@ -499,8 +485,8 @@ export default {
       }
     },
     async loadStalwartPasswords() {
-      let url = "/apps/imap_manager/stalwart/get";
-      let result = await this.csrfRequest(url, "GET");
+      let url = generateUrl("/apps/imap_manager/stalwart/get");
+      let result = await axios.get(url);
       if (result.data.success) {
         this.stalwartPasswords = result.data.passwords.map((p) => ({
           ...p,
@@ -513,9 +499,9 @@ export default {
         return;
       }
       this.stalwartToken = uuidv4();
-      let url = "/apps/imap_manager/stalwart/set";
+      let url = generateUrl("/apps/imap_manager/stalwart/set");
       let params = { name: this.stalwartName, password: this.stalwartToken };
-      let result = await this.csrfRequest(url, "POST", params);
+      let result = await axios.post(url, params);
       if (result.data.success) {
         this.showStalwartDialog = true;
         this.stalwartPasswords.push({
@@ -527,9 +513,9 @@ export default {
       }
     },
     async deleteStalwart(name, password) {
-      let url = "/apps/imap_manager/stalwart/delete";
+      let url = generateUrl("/apps/imap_manager/stalwart/delete");
       let params = { name: name, password: password };
-      let result = await this.csrfRequest(url, "POST", params);
+      let result = await axios.post(url, params);
       if (result.data.success) {
         this.stalwartPasswords = this.stalwartPasswords.filter(
           (p) => !(p.name === name && p.password === password)

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -306,6 +306,11 @@ import axios from "@nextcloud/axios";
 import { generateUrl } from "@nextcloud/router";
 import { showSuccess } from "@nextcloud/dialogs";
 import { t } from "@nextcloud/l10n";
+import {
+  confirmPassword,
+  isPasswordConfirmationRequired,
+} from "@nextcloud/password-confirmation";
+import "@nextcloud/password-confirmation/style.css";
 import { v4 as uuidv4 } from "uuid";
 
 export default {
@@ -418,6 +423,9 @@ export default {
       let url = generateUrl("/apps/imap_manager/set");
 
       let params = { token: this.token, name: this.name };
+      if (isPasswordConfirmationRequired()) {
+        await confirmPassword();
+      }
       let result = await axios.post(url, params);
       if (result.data.success == true) {
         console.log("New IMAP password set");
@@ -472,6 +480,9 @@ export default {
     async unset(id) {
       let url = generateUrl("/apps/imap_manager/delete");
       let params = { id: id };
+      if (isPasswordConfirmationRequired()) {
+        await confirmPassword();
+      }
       let result = await axios.post(url, params);
       if (result.data.success == true) {
         for (var i = 0; i < this.tokens.length; i++) {
@@ -501,6 +512,9 @@ export default {
       this.stalwartToken = uuidv4();
       let url = generateUrl("/apps/imap_manager/stalwart/set");
       let params = { name: this.stalwartName, password: this.stalwartToken };
+      if (isPasswordConfirmationRequired()) {
+        await confirmPassword();
+      }
       let result = await axios.post(url, params);
       if (result.data.success) {
         this.showStalwartDialog = true;
@@ -515,6 +529,9 @@ export default {
     async deleteStalwart(name, password) {
       let url = generateUrl("/apps/imap_manager/stalwart/delete");
       let params = { name: name, password: password };
+      if (isPasswordConfirmationRequired()) {
+        await confirmPassword();
+      }
       let result = await axios.post(url, params);
       if (result.data.success) {
         this.stalwartPasswords = this.stalwartPasswords.filter(


### PR DESCRIPTION
## Summary

Addresses findings from the Copilot security audit, in scope agreed with maintainer.

### Security
- **C1 IDOR on `delete()`** — verify the IMAP password row belongs to the calling user (403 otherwise, 404 on missing). Previously any authenticated user could delete any other user's app passwords by guessing the integer id.
- **H4** — `setStalwart()` / `deleteStalwart()` now reject `\$` in the password too, not only in the name. Prevents secret-format corruption if a bring-your-own-password path is ever added.

### Reliability
- **H1** — `StalwartService::request()` inspects the HTTP status and throws on non-2xx. Stalwart 401/403 no longer masquerade as success.
- **M2** — `set()` / `setSync()` wrap mapper calls in try/catch. The mappers throw `InvalidArgumentException` and never returned null, so the old null guard followed by `->getId()` was dead code that turned real errors into 500s. Now returns 400.
- **M3** — `setSync()` validates `frequency` against `{daily,hourly,minutely}` and `primary` against `{sunet,m365}` server-side. Previously stored verbatim.
- **M5** — `testConnection()` hits `/api/principal` (list) instead of `/api/principal/<admin_user>`, so it probes admin auth without depending on a specific principal existing.

### Schema
- **M1** — new `Version00500` migration adds a unique index on `(user_id, name)` in `imap_manager_users` to back `insertOrUpdate`'s upsert semantics. Shrinks the `name` column to 255 chars if previously longer, to stay within InnoDB index-size limits.

### Frontend
- **M4** — `PersonalSettings.vue` drops the custom `csrfRequest` helper and calls `@nextcloud/axios` directly. `@nextcloud/axios` already injects the `requesttoken` header via `OC.requestToken`, so the extra `/csrftoken` round-trip was unnecessary (and not actually what Nextcloud's CSRF middleware checks).

## Out of scope

Discussed separately:
- **C2, C3, H5** — architectural (Stalwart secret hashing / one-shot reveal / canonical principal identity). Requires product alignment.
- **H2** — Dovecot hash stays as SHA3-512 over a salted UUIDv4: slow hashes (Argon2/bcrypt) are for low-entropy passwords, not 122-bit random tokens, and the algorithm must match what Dovecot verifies.
- **H3** — rate limiting. Worth doing but needs limit tuning.
- **M6, L1-L10** — low priority / informational.

## Test plan
- [ ] User A cannot delete user B's IMAP password via `POST /apps/imap_manager/delete` with a guessed id (expect 403 / 404; their own rows still delete).
- [ ] `POST /apps/imap_manager/set_sync` with `frequency=weekly` or `primary=google` returns 400.
- [ ] Stalwart CRUD still works end-to-end in personal settings.
- [ ] Stalwart create/delete still return a sensible error (not success) when Stalwart returns 401/403.
- [ ] Stalwart test-connection still works with correct admin creds, and fails with wrong creds.
- [ ] `occ upgrade` applies the new migration cleanly on MySQL and PostgreSQL.
- [ ] Attempting a second app password with the same name per user is rejected once the unique index is in place.